### PR TITLE
Fixed loss of precission on division

### DIFF
--- a/BigFloat/BigFloat.cs
+++ b/BigFloat/BigFloat.cs
@@ -405,24 +405,19 @@
 				return Zero;
 			BigInteger valA = a.Value;
 			BigInteger valB = b.Value;
-			int radix;
-			if (a.Radix == b.Radix)
-				radix = a.Radix;
-			else if (a.Radix > b.Radix)
+			if (a.Radix > b.Radix)
 			{
-				radix = a.Radix;
 				valB *= BigInteger.Pow(10, a.Radix - b.Radix);
 			}
 			else
 			{
-				radix = b.Radix;
 				valA *= BigInteger.Pow(10, b.Radix - a.Radix);
 			}
 			BigInteger result = BigInteger.Zero;
-			BigInteger mult = BigInteger.Pow(10, radix);
+			int radix = 0;
 			while (true)
 			{
-				result += BigInteger.DivRem(valA, valB, out valA) * mult;
+				result += BigInteger.DivRem(valA, valB, out valA);
 				if (valA.IsZero)
 					break;
 				if (radix > divmax)


### PR DESCRIPTION
The output radix was initalized to common input radix, which doesn't make sense in context of iterative division (first division gives you the whole part, regardless of input order of magnitude).

The result is effectively multiplied by 10 to the initial radix.

This ends up wasting space, e.g. `1.11 / 3 = 3700 radix 4`. BigFloat constructor normalizes this to `37 radix 2`, but this doesn't affect maxdiv limit, which checks the multiplied result.

Here are examples with precission loss:
 - `2 / 1.4` -  produces a number with radix 1000 instead of maximum 1001
 - `(2 / 1.4) / 2` - number with radix 1 (again, instead of max 1001)

Fixed by initalizing radix to 0.